### PR TITLE
Feature/issue#11 - 테스트 커버리지 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,13 +39,12 @@ tasks.named('test') {
 
 jacocoTestReport {
     reports {
-        xml.required = false
         csv.required = false
-        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+        xml.required = false
+        html.required = true
     }
 
     finalizedBy 'jacocoTestCoverageVerification'
-
 }
 
 jacocoTestCoverageVerification {
@@ -54,6 +53,7 @@ jacocoTestCoverageVerification {
             enabled = true
             element = 'CLASS'
             excludes = [
+                    'com.petitapetit.miml.MimlApplication',
                     '*.*Dto',
                     '*.*Config',
                     '*.*Test',

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.16'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'jacoco'
 }
 
 group = 'com.petitapetit'
@@ -33,4 +34,37 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = false
+        csv.required = false
+        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification'
+
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+            excludes = [
+                    '*.*Dto',
+                    '*.*Config',
+                    '*.*Test',
+                    '*.dto.*',
+            ]
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.6
+            }
+        }
+    }
 }


### PR DESCRIPTION
### ✍️ Description
- #11 에 따라 단단한 테스트 코드 작성은 `MIML` 중요한 목적 중 하나입니다. 테스트 코드 작성을 준수하는지 정량적인 측정을 위해 TestCoverage tool 중 하나인 `jacoco`를 도입하게 되었습니다.

<br>

### 🎯 Key Changes
- `build.gradle`에 `jacoco plugin` 도입
- html report 저장
- 예외 클래스 추가(dto, test, config)
- line coverage ratio 0.6 이상으로 설정


<br>

### 💬 To Reviewers
- 제외되어야 할 `className`
- 추가 질문사항이 있으면 남겨주세요
