### PR TITLE
Feature/issue#36 - 코드 리팩토링

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "config"]
+	path = config
+	url = https://github.com/petit-a-petit/MIML-config.git

--- a/src/main/java/com/petitapetit/miml/domain/auth/oauth/filter/OriginalUriFilter.java
+++ b/src/main/java/com/petitapetit/miml/domain/auth/oauth/filter/OriginalUriFilter.java
@@ -9,6 +9,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.petitapetit.miml.global.util.SessionUtil;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -18,9 +20,7 @@ public class OriginalUriFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 		throws ServletException, IOException {
 
-		String originalRequestUri = request.getRequestURI();
-		request.getSession().setAttribute("originalRequestUri", originalRequestUri);
-
+		SessionUtil.setOriginalRequestUri(request.getSession(), request.getRequestURI());
 		filterChain.doFilter(request, response);
 	}
 }

--- a/src/main/java/com/petitapetit/miml/domain/auth/oauth/handler/CustomOAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/petitapetit/miml/domain/auth/oauth/handler/CustomOAuth2AuthenticationSuccessHandler.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.petitapetit.miml.domain.auth.oauth.CustomOAuth2User;
+import com.petitapetit.miml.global.util.SessionUtil;
 
 @Component
 public class CustomOAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
@@ -35,7 +36,7 @@ public class CustomOAuth2AuthenticationSuccessHandler extends SimpleUrlAuthentic
 		String accessToken = oauthUser.getAccessToken();
 
 		SecurityContextHolder.getContext().setAuthentication(authentication);
-		String originalRequestUri = (String) request.getSession().getAttribute("originalRequestUri");
+		String originalRequestUri = SessionUtil.getOriginalRequestUri(request.getSession());
 
 		String targetUrl = createTargetUrl(originalRequestUri);
 		getRedirectStrategy().sendRedirect(request, response, targetUrl);

--- a/src/main/java/com/petitapetit/miml/domain/member/api/MemberController.java
+++ b/src/main/java/com/petitapetit/miml/domain/member/api/MemberController.java
@@ -1,5 +1,6 @@
 package com.petitapetit.miml.domain.member.api;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -7,21 +8,24 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.client.RestTemplate;
 
 import com.petitapetit.miml.domain.auth.oauth.CustomOAuth2User;
 
+
 @Controller
 public class MemberController {
 
-	// @Value("${spotify.api.url}")
-	private String spotifyApiUrl = "https://api.spotify.com"; // Spotify API 엔드포인트 URL
+	@Value("${spotify.host}")
+	private String SpotifyHost;
+
+	@Value("${spotify.endpoint.me}")
+	private String myDataEndpoint;
 
 	@GetMapping("/me")
 	public ResponseEntity<String> getMySpotifyData(@AuthenticationPrincipal CustomOAuth2User oAuth2User) {
 
-		String apiUrl = spotifyApiUrl + "/v1/me";
+		String apiUrl = SpotifyHost + myDataEndpoint;
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("Authorization", "Bearer " + oAuth2User.getAccessToken());

--- a/src/main/java/com/petitapetit/miml/domain/member/model/MemberId.java
+++ b/src/main/java/com/petitapetit/miml/domain/member/model/MemberId.java
@@ -1,6 +1,7 @@
 package com.petitapetit.miml.domain.member.model;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
@@ -22,4 +23,19 @@ public class MemberId implements Serializable {
 	@Enumerated(EnumType.STRING)
 	private OAuth2Provider provider;
 	private String providerId;
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		MemberId memberId = (MemberId) o;
+		return Objects.equals(getProvider(), memberId.getProvider())
+			&& Objects.equals(getProviderId(), memberId.getProviderId());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getProvider(), getProviderId());
+	}
 }

--- a/src/main/java/com/petitapetit/miml/global/util/SessionUtil.java
+++ b/src/main/java/com/petitapetit/miml/global/util/SessionUtil.java
@@ -2,24 +2,23 @@ package com.petitapetit.miml.global.util;
 
 import javax.servlet.http.HttpSession;
 
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
 public class SessionUtil {
 	private static final String ORIGINAL_REQUEST_URI = "ORIGINAL_REQUEST_URI";
-
-	// 인스턴스화 방지
-	private SessionUtil() {
-	}
 
 	/**
 	 * 로그인을 시도한 유저가 접속하고자 하는 ORIGINAL URI 를 세션에 저장한다.
 	 */
-	public static void setOriginalRequestUri(HttpSession session, String originalRequestUri) {
+	public void setOriginalRequestUri(HttpSession session, String originalRequestUri) {
 		session.setAttribute(ORIGINAL_REQUEST_URI, originalRequestUri);
 	}
 
 	/**
 	 * 로그인한 유저가 접속하고자 했던 ORIGINAL URI 를 세션에서 꺼낸다.
 	 */
-	public static String getOriginalRequestUri(HttpSession session) {
+	public String getOriginalRequestUri(HttpSession session) {
 		return (String) session.getAttribute(ORIGINAL_REQUEST_URI);
 	}
 

--- a/src/main/java/com/petitapetit/miml/global/util/SessionUtil.java
+++ b/src/main/java/com/petitapetit/miml/global/util/SessionUtil.java
@@ -1,0 +1,26 @@
+package com.petitapetit.miml.global.util;
+
+import javax.servlet.http.HttpSession;
+
+public class SessionUtil {
+	private static final String ORIGINAL_REQUEST_URI = "ORIGINAL_REQUEST_URI";
+
+	// 인스턴스화 방지
+	private SessionUtil() {
+	}
+
+	/**
+	 * 로그인을 시도한 유저가 접속하고자 하는 ORIGINAL URI 를 세션에 저장한다.
+	 */
+	public static void setOriginalRequestUri(HttpSession session, String originalRequestUri) {
+		session.setAttribute(ORIGINAL_REQUEST_URI, originalRequestUri);
+	}
+
+	/**
+	 * 로그인한 유저가 접속하고자 했던 ORIGINAL URI 를 세션에서 꺼낸다.
+	 */
+	public static String getOriginalRequestUri(HttpSession session) {
+		return (String) session.getAttribute(ORIGINAL_REQUEST_URI);
+	}
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,7 @@ spring:
   profiles:
     include:
       - oauth
+      - spotify
   jpa:
     hibernate:
       generate-ddl: true


### PR DESCRIPTION
### ✍️ Description
- 유지보수성 향상을 위해 코드를 리팩토링합니다.

<br>

### 🎯 Key Changes
- 사용자의 `originalRequestUri`를 세션에 저장하고, 세선에서 가져오기 위한 유틸리티 클래스를 작성했습니다.
- 민감정보를 보다 효율적으로 관리하기 위해 서브모듈을 등록했습니다. 
    - 서브모듈을 등록하면, 번거롭게 파일로 주고받을 필요없이 git을 통해 형상관리를 할 수 있습니다. 🙂
- 복합키를 사용하기 위해 `equals()`와 `hashcode()` 메서드를 재정의했습니다.

<br>

### 💬 To Reviewers
- 서브모듈은 private 레포지토리로 생성했습니다. (organization 내 `MIML-config` 레포지토리)
- `git submodule init` -> `git submodule update --remote` 커맨드로 불러올 수 있습니다!
- 서브모듈 주의사항 🔥
    - 로컬에서 서브모듈에 등록된 파일을 수정한 경우, 반드시 서브모듈 파일을 먼저 push 한 후 메인 프로젝트를 push 해야합니다.
    - 일반적인 `git push` 대신 `git push --recurse-submodules=on-demand` 커맨드로 안전하게 push 하기를 권장합니다. (git이 메인 프로젝트를 push 하기 전에 서브모듈의 변경 사항이 있다면 서브모듈을 먼저 push 해주는 옵션)
