### PR TITLE
Feature/issue#13 플레이리스트 등록, 수정, 조회, 삭제 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'com.google.code.gson:gson'
+    implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+    annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/petitapetit/miml/MimlApplication.java
+++ b/src/main/java/com/petitapetit/miml/MimlApplication.java
@@ -3,6 +3,7 @@ package com.petitapetit.miml;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+
 @SpringBootApplication
 public class MimlApplication {
 
@@ -11,3 +12,4 @@ public class MimlApplication {
     }
 
 }
+

--- a/src/main/java/com/petitapetit/miml/domain/playlist/controller/PlayListController.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/controller/PlayListController.java
@@ -41,17 +41,17 @@ public class PlayListController {
     }
 
     @GetMapping("/{play_list_id}")
-    public ResponseEntity<PlayListDto.Response> getPlayListDetail(@PathVariable("play_list_id") Long playListId){
+    public ResponseEntity<PlayListDto.DetailResponse> getPlayListDetail(@PathVariable("play_list_id") Long playListId){
 
-        PlayListDto.Response response = playListService.getPlayListById(playListId);
+        PlayListDto.DetailResponse response = playListService.getPlayListById(playListId);
 
         return ResponseEntity.ok(response);
     }
 
     @GetMapping
-    public ResponseEntity<List<PlayListDto.Response>> getPlayLists(){
+    public ResponseEntity<List<PlayListDto.DetailResponse>> getPlayLists(){
 
-        List<PlayListDto.Response> response = playListService.getPlayLists();
+        List<PlayListDto.DetailResponse> response = playListService.getPlayLists();
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/controller/PlayListController.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/controller/PlayListController.java
@@ -17,11 +17,11 @@ public class PlayListController {
     private final PlayListService playListService;
 
     @PostMapping
-    public ResponseEntity postPlayList(@RequestBody PlayListDto.SaveRequest request){
+    public ResponseEntity<PlayListDto.SaveResponse> postPlayList(@RequestBody PlayListDto.SaveRequest request){
 
         Long memberId = 1L; //mock
-        playListService.savePlayList(request , memberId);
+        PlayListDto.SaveResponse response = playListService.savePlayList(request , memberId);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/controller/PlayListController.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/controller/PlayListController.java
@@ -2,12 +2,13 @@ package com.petitapetit.miml.domain.playlist.controller;
 
 import com.petitapetit.miml.domain.playlist.dto.PlayListDto;
 import com.petitapetit.miml.domain.playlist.service.PlayListService;
+import com.petitapetit.miml.util.UriUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/playlists")
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlayListController {
 
     private final PlayListService playListService;
+    public static final String DEFAULT_URI = "/playlists";
+
 
     @PostMapping
     public ResponseEntity<PlayListDto.SaveResponse> postPlayList(@RequestBody PlayListDto.SaveRequest request){
@@ -22,6 +25,43 @@ public class PlayListController {
         Long memberId = 1L; //mock
         PlayListDto.SaveResponse response = playListService.savePlayList(request , memberId);
 
+        URI uri = UriUtil.createUri(DEFAULT_URI, response.getPlayListId());
+
+        return ResponseEntity.created(uri).body(response);
+    }
+
+    @PatchMapping("/{play_list_id}")
+    public ResponseEntity<PlayListDto.SaveResponse> patchPlayList(@PathVariable("play_list_id") Long playListId,
+                                                                  @RequestBody PlayListDto.SaveRequest request){
+
+        Long memberId = 1L;//mock
+        PlayListDto.SaveResponse response = playListService.modifyPlayList(playListId, request, memberId);
+
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{play_list_id}")
+    public ResponseEntity<PlayListDto.Response> getPlayListDetail(@PathVariable("play_list_id") Long playListId){
+
+        PlayListDto.Response response = playListService.getPlayListById(playListId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PlayListDto.Response>> getPlayLists(){
+
+        List<PlayListDto.Response> response = playListService.getPlayLists();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{play_list_id}")
+    public ResponseEntity<String> deletePlayList(@PathVariable("play_list_id") Long playListId){
+
+        Long memberId = 1L;
+        playListService.deletePlayList(playListId, memberId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/controller/PlayListController.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/controller/PlayListController.java
@@ -1,6 +1,8 @@
 package com.petitapetit.miml.domain.playlist.controller;
 
 import com.petitapetit.miml.domain.playlist.dto.PlayListDto;
+import com.petitapetit.miml.domain.playlist.service.PlayListService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -9,10 +11,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/playlists")
+@RequiredArgsConstructor
 public class PlayListController {
 
+    private final PlayListService playListService;
+
     @PostMapping
-    public ResponseEntity postPlayList(@RequestBody PlayListDto.Post requestBody){
+    public ResponseEntity postPlayList(@RequestBody PlayListDto.SaveRequest request){
+
+        Long memberId = 1L; //mock
+        playListService.savePlayList(request , memberId);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/dto/PlayListDto.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/dto/PlayListDto.java
@@ -14,4 +14,10 @@ public class PlayListDto {
         private String name;
         private Boolean isPublic;
     }
+
+    @AllArgsConstructor @NoArgsConstructor
+    @Builder @Getter
+    public static class SaveResponse {
+        private Long playListId;
+    }
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/dto/PlayListDto.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/dto/PlayListDto.java
@@ -2,13 +2,12 @@ package com.petitapetit.miml.domain.playlist.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 public class PlayListDto {
 
     @AllArgsConstructor @NoArgsConstructor
     public static class Post {
         private String name;
-        private boolean publicYN;
+        private boolean isPublic;
     }
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/dto/PlayListDto.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/dto/PlayListDto.java
@@ -25,7 +25,7 @@ public class PlayListDto {
 
     @AllArgsConstructor @NoArgsConstructor
     @Builder @Getter
-    public static class Response {
+    public static class DetailResponse {
         private String name;
         private Boolean isPublic;
         //등록된 노래

--- a/src/main/java/com/petitapetit/miml/domain/playlist/dto/PlayListDto.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/dto/PlayListDto.java
@@ -19,5 +19,16 @@ public class PlayListDto {
     @Builder @Getter
     public static class SaveResponse {
         private Long playListId;
+        private String name;
+        private Boolean isPublic;
+    }
+
+    @AllArgsConstructor @NoArgsConstructor
+    @Builder @Getter
+    public static class Response {
+        private String name;
+        private Boolean isPublic;
+        //등록된 노래
+        //소유자 이름
     }
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/dto/PlayListDto.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/dto/PlayListDto.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 public class PlayListDto {
 
     @AllArgsConstructor @NoArgsConstructor
-    public static class Post {
+    public static class SaveRequest {
         private String name;
         private boolean isPublic;
     }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/dto/PlayListDto.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/dto/PlayListDto.java
@@ -1,13 +1,17 @@
 package com.petitapetit.miml.domain.playlist.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 public class PlayListDto {
 
     @AllArgsConstructor @NoArgsConstructor
+    @Getter @Builder
     public static class SaveRequest {
         private String name;
-        private boolean isPublic;
+        private Boolean isPublic;
     }
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/entity/PlayList.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/entity/PlayList.java
@@ -22,4 +22,12 @@ public class PlayList {
     private Long memberId;
 
     private Boolean isPublic;
+
+    public void updateIsPublic(Boolean isPublic){
+        this.isPublic = isPublic;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/entity/PlayList.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/entity/PlayList.java
@@ -1,0 +1,28 @@
+package com.petitapetit.miml.domain.playlist.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class PlayList {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long playListId;
+
+    private String name;
+
+    private Long memberId;
+
+    private boolean publicYN;
+}

--- a/src/main/java/com/petitapetit/miml/domain/playlist/entity/PlayList.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/entity/PlayList.java
@@ -1,9 +1,6 @@
 package com.petitapetit.miml.domain.playlist.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -14,7 +11,7 @@ import javax.persistence.Id;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Getter
+@Getter @Setter
 public class PlayList {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/petitapetit/miml/domain/playlist/entity/PlayList.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/entity/PlayList.java
@@ -24,5 +24,5 @@ public class PlayList {
 
     private Long memberId;
 
-    private boolean publicYN;
+    private Boolean isPublic;
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/mapper/PlayListMapper.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/mapper/PlayListMapper.java
@@ -18,7 +18,7 @@ public interface PlayListMapper {
 
     PlayListDto.SaveResponse playListToSaveResponse(PlayList savedPlayList);
 
-    PlayListDto.Response playListToResponse(PlayList playList);
+    PlayListDto.DetailResponse playListToDetailResponse(PlayList playList);
 
-    List<PlayListDto.Response> playListsToResponse(List<PlayList> playLists);
+    List<PlayListDto.DetailResponse> playListsToDetailResponseLists(List<PlayList> playLists);
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/mapper/PlayListMapper.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/mapper/PlayListMapper.java
@@ -1,0 +1,16 @@
+package com.petitapetit.miml.domain.playlist.mapper;
+
+import com.petitapetit.miml.domain.playlist.dto.PlayListDto;
+import com.petitapetit.miml.domain.playlist.entity.PlayList;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface PlayListMapper {
+    default PlayList SaveRequestToPlayList(PlayListDto.SaveRequest saveRequest, Long memberId){
+
+        return PlayList.builder()
+                .name(saveRequest.getName())
+                .memberId(memberId)
+                .isPublic(saveRequest.getIsPublic()).build();
+    }
+}

--- a/src/main/java/com/petitapetit/miml/domain/playlist/mapper/PlayListMapper.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/mapper/PlayListMapper.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface PlayListMapper {
-    default PlayList SaveRequestToPlayList(PlayListDto.SaveRequest saveRequest, Long memberId){
+    default PlayList saveRequestToPlayList(PlayListDto.SaveRequest saveRequest, Long memberId){
 
         return PlayList.builder()
                 .name(saveRequest.getName())
@@ -16,9 +16,9 @@ public interface PlayListMapper {
                 .isPublic(saveRequest.getIsPublic()).build();
     }
 
-    PlayListDto.SaveResponse PlayListToSaveResponse(PlayList savedPlayList);
+    PlayListDto.SaveResponse playListToSaveResponse(PlayList savedPlayList);
 
-    PlayListDto.Response PlayListToResponse(PlayList playList);
+    PlayListDto.Response playListToResponse(PlayList playList);
 
-    List<PlayListDto.Response> PlayListsToResponse(List<PlayList> playLists);
+    List<PlayListDto.Response> playListsToResponse(List<PlayList> playLists);
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/mapper/PlayListMapper.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/mapper/PlayListMapper.java
@@ -4,6 +4,8 @@ import com.petitapetit.miml.domain.playlist.dto.PlayListDto;
 import com.petitapetit.miml.domain.playlist.entity.PlayList;
 import org.mapstruct.Mapper;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring")
 public interface PlayListMapper {
     default PlayList SaveRequestToPlayList(PlayListDto.SaveRequest saveRequest, Long memberId){
@@ -15,4 +17,8 @@ public interface PlayListMapper {
     }
 
     PlayListDto.SaveResponse PlayListToSaveResponse(PlayList savedPlayList);
+
+    PlayListDto.Response PlayListToResponse(PlayList playList);
+
+    List<PlayListDto.Response> PlayListsToResponse(List<PlayList> playLists);
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/mapper/PlayListMapper.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/mapper/PlayListMapper.java
@@ -13,4 +13,6 @@ public interface PlayListMapper {
                 .memberId(memberId)
                 .isPublic(saveRequest.getIsPublic()).build();
     }
+
+    PlayListDto.SaveResponse PlayListToSaveResponse(PlayList savedPlayList);
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/repository/PlayListRepository.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/repository/PlayListRepository.java
@@ -1,0 +1,9 @@
+package com.petitapetit.miml.domain.playlist.repository;
+
+import com.petitapetit.miml.domain.playlist.entity.PlayList;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlayListRepository extends JpaRepository<PlayList, Long> {
+}

--- a/src/main/java/com/petitapetit/miml/domain/playlist/service/PlayListService.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/service/PlayListService.java
@@ -14,10 +14,12 @@ public class PlayListService {
     private final PlayListRepository playListRepository;
     private final PlayListMapperImpl playListMapper;
 
-    public PlayList savePlayList(PlayListDto.SaveRequest request, Long memberId) {
+    public PlayListDto.SaveResponse savePlayList(PlayListDto.SaveRequest request, Long memberId) {
 
         PlayList playList = playListMapper.SaveRequestToPlayList(request, memberId);
 
-        return playListRepository.save(playList);
+        PlayList savedPlayList = playListRepository.save(playList);
+
+        return playListMapper.PlayListToSaveResponse(savedPlayList);
     }
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/service/PlayListService.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/service/PlayListService.java
@@ -1,7 +1,18 @@
 package com.petitapetit.miml.domain.playlist.service;
 
+import com.petitapetit.miml.domain.playlist.entity.PlayList;
+import com.petitapetit.miml.domain.playlist.repository.PlayListRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class PlayListService {
+
+    private final PlayListRepository playListRepository;
+
+    public PlayList savePlayList(PlayList playList) {
+
+        return playListRepository.save(playList);
+    }
 }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/service/PlayListService.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/service/PlayListService.java
@@ -5,7 +5,14 @@ import com.petitapetit.miml.domain.playlist.entity.PlayList;
 import com.petitapetit.miml.domain.playlist.mapper.PlayListMapper;
 import com.petitapetit.miml.domain.playlist.repository.PlayListRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +28,63 @@ public class PlayListService {
         PlayList savedPlayList = playListRepository.save(playList);
 
         return playListMapper.PlayListToSaveResponse(savedPlayList);
+    }
+
+    public PlayListDto.SaveResponse modifyPlayList(Long playListId, PlayListDto.SaveRequest request, Long memberId) {
+        PlayList playList = getVerifiedPlaylist(playListId, memberId);
+
+        if (request.getIsPublic() != null) {
+            playList.setIsPublic(request.getIsPublic());
+        }
+
+        if(request.getName() != null){
+            playList.setName(request.getName());
+        }
+
+        PlayList modifiedPlayList = playListRepository.save(playList);
+
+        return playListMapper.PlayListToSaveResponse(modifiedPlayList);
+    }
+
+    public PlayListDto.Response getPlayListById(Long playListId) {
+
+        PlayList playList = checkExistence(playListId);
+
+        return playListMapper.PlayListToResponse(playList);
+    }
+
+    public List<PlayListDto.Response> getPlayLists(){
+
+        List<PlayList> playLists = playListRepository.findAll();
+
+        return playListMapper.PlayListsToResponse(playLists);
+    }
+
+    public void deletePlayList(Long playListId, Long memberId){
+
+        PlayList playList = getVerifiedPlaylist(playListId, memberId);
+
+        playListRepository.delete(playList);
+    }
+
+    @Transactional
+    public PlayList getVerifiedPlaylist(Long playListId, Long memberId) {
+
+        PlayList playList = checkExistence(playListId);
+        checkAuthorization(memberId, playList);
+
+        return playList;
+    }
+
+    private void checkAuthorization(Long memberId, PlayList playList) {
+        if(!Objects.equals(playList.getPlayListId(), memberId)){
+            throw new RuntimeException(String.valueOf(HttpStatus.UNAUTHORIZED)); //추후 예외처리 정리 예정
+        }
+    }
+
+    private PlayList checkExistence(Long PlayListId) {
+        Optional<PlayList> optional = playListRepository.findById(PlayListId);
+        return optional.orElseThrow(NoSuchElementException::new); //추후 예외처리 정리 예정
     }
 }
 

--- a/src/main/java/com/petitapetit/miml/domain/playlist/service/PlayListService.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/service/PlayListService.java
@@ -1,6 +1,8 @@
 package com.petitapetit.miml.domain.playlist.service;
 
+import com.petitapetit.miml.domain.playlist.dto.PlayListDto;
 import com.petitapetit.miml.domain.playlist.entity.PlayList;
+import com.petitapetit.miml.domain.playlist.mapper.PlayListMapperImpl;
 import com.petitapetit.miml.domain.playlist.repository.PlayListRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,8 +12,11 @@ import org.springframework.stereotype.Service;
 public class PlayListService {
 
     private final PlayListRepository playListRepository;
+    private final PlayListMapperImpl playListMapper;
 
-    public PlayList savePlayList(PlayList playList) {
+    public PlayList savePlayList(PlayListDto.SaveRequest request, Long memberId) {
+
+        PlayList playList = playListMapper.SaveRequestToPlayList(request, memberId);
 
         return playListRepository.save(playList);
     }

--- a/src/main/java/com/petitapetit/miml/domain/playlist/service/PlayListService.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/service/PlayListService.java
@@ -4,13 +4,13 @@ import com.petitapetit.miml.domain.playlist.dto.PlayListDto;
 import com.petitapetit.miml.domain.playlist.entity.PlayList;
 import com.petitapetit.miml.domain.playlist.mapper.PlayListMapper;
 import com.petitapetit.miml.domain.playlist.repository.PlayListRepository;
+import com.petitapetit.miml.global.exception.CommonErrorCode;
+import com.petitapetit.miml.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -78,13 +78,12 @@ public class PlayListService {
 
     private void checkAuthorization(Long memberId, PlayList playList) {
         if(!Objects.equals(playList.getPlayListId(), memberId)){
-            throw new RuntimeException(String.valueOf(HttpStatus.UNAUTHORIZED)); //추후 예외처리 정리 예정
+            throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND); //추후 상태 코드 결정
         }
     }
 
     private PlayList checkExistence(Long PlayListId) {
         Optional<PlayList> optional = playListRepository.findById(PlayListId);
-        return optional.orElseThrow(NoSuchElementException::new); //추후 예외처리 정리 예정
+        return optional.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND)); //추후 상태 코드 결정
     }
 }
-

--- a/src/main/java/com/petitapetit/miml/domain/playlist/service/PlayListService.java
+++ b/src/main/java/com/petitapetit/miml/domain/playlist/service/PlayListService.java
@@ -2,7 +2,7 @@ package com.petitapetit.miml.domain.playlist.service;
 
 import com.petitapetit.miml.domain.playlist.dto.PlayListDto;
 import com.petitapetit.miml.domain.playlist.entity.PlayList;
-import com.petitapetit.miml.domain.playlist.mapper.PlayListMapperImpl;
+import com.petitapetit.miml.domain.playlist.mapper.PlayListMapper;
 import com.petitapetit.miml.domain.playlist.repository.PlayListRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 public class PlayListService {
 
     private final PlayListRepository playListRepository;
-    private final PlayListMapperImpl playListMapper;
+    private final PlayListMapper playListMapper;
 
     public PlayListDto.SaveResponse savePlayList(PlayListDto.SaveRequest request, Long memberId) {
 
@@ -23,3 +23,4 @@ public class PlayListService {
         return playListMapper.PlayListToSaveResponse(savedPlayList);
     }
 }
+

--- a/src/main/java/com/petitapetit/miml/global/exception/BusinessException.java
+++ b/src/main/java/com/petitapetit/miml/global/exception/BusinessException.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
-public class RestApiException extends RuntimeException{
+public class BusinessException extends RuntimeException{
 
     private final ErrorCode errorCode;
 }

--- a/src/main/java/com/petitapetit/miml/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/petitapetit/miml/global/exception/CommonErrorCode.java
@@ -1,0 +1,15 @@
+package com.petitapetit.miml.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum CommonErrorCode implements ErrorCode{
+
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/petitapetit/miml/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/petitapetit/miml/global/exception/CommonErrorCode.java
@@ -8,8 +8,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum CommonErrorCode implements ErrorCode{
 
-    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists");
+    FORBIDDEN(HttpStatus.FORBIDDEN, "플레이리스트에 대한 권한이 없습니다."),
+    PLAYLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "플레이리스트가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;
+
 }

--- a/src/main/java/com/petitapetit/miml/global/exception/ErrorCode.java
+++ b/src/main/java/com/petitapetit/miml/global/exception/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.petitapetit.miml.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    String name();
+    HttpStatus getHttpStatus();
+    String getMessage();
+
+}
+

--- a/src/main/java/com/petitapetit/miml/global/exception/ErrorResponse.java
+++ b/src/main/java/com/petitapetit/miml/global/exception/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.petitapetit.miml.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Builder @Getter
+@RequiredArgsConstructor
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/petitapetit/miml/global/exception/ErrorResponse.java
+++ b/src/main/java/com/petitapetit/miml/global/exception/ErrorResponse.java
@@ -4,10 +4,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Builder @Getter
 @RequiredArgsConstructor
 public class ErrorResponse {
 
     private final String code;
     private final String message;
+    private final LocalDateTime timestamp;
 }

--- a/src/main/java/com/petitapetit/miml/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/petitapetit/miml/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.petitapetit.miml.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+
+    @ExceptionHandler(RestApiException.class)
+    public ResponseEntity<Object> handleCustomException(RestApiException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode));
+    }
+
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/petitapetit/miml/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/petitapetit/miml/global/exception/GlobalExceptionHandler.java
@@ -5,13 +5,15 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import java.time.LocalDateTime;
+
 
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 
-    @ExceptionHandler(RestApiException.class)
-    public ResponseEntity<Object> handleCustomException(RestApiException e) {
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<Object> handleCustomException(BusinessException e) {
         ErrorCode errorCode = e.getErrorCode();
         return handleExceptionInternal(errorCode);
     }
@@ -25,6 +27,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return ErrorResponse.builder()
                 .code(errorCode.name())
                 .message(errorCode.getMessage())
+                .timestamp(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/java/com/petitapetit/miml/global/exception/RestApiException.java
+++ b/src/main/java/com/petitapetit/miml/global/exception/RestApiException.java
@@ -1,0 +1,11 @@
+package com.petitapetit.miml.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class RestApiException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/petitapetit/miml/util/UriUtil.java
+++ b/src/main/java/com/petitapetit/miml/util/UriUtil.java
@@ -1,14 +1,16 @@
 package com.petitapetit.miml.util;
 
+import lombok.experimental.UtilityClass;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 
+@UtilityClass
 public class UriUtil {
-    public static URI createUri(String defaultUrl, Long resourceId) {
+    public static URI createUri(String defaultUrl, Long uriPathVariable) {
         return UriComponentsBuilder.newInstance()
-                .path(defaultUrl + "/{resource-id}")
-                .buildAndExpand(resourceId)
+                .path(defaultUrl + "/{uri-path-variable}")
+                .buildAndExpand(uriPathVariable)
                 .toUri();
     }
 }

--- a/src/main/java/com/petitapetit/miml/util/UriUtil.java
+++ b/src/main/java/com/petitapetit/miml/util/UriUtil.java
@@ -1,0 +1,14 @@
+package com.petitapetit.miml.util;
+
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+public class UriUtil {
+    public static URI createUri(String defaultUrl, Long resourceId) {
+        return UriComponentsBuilder.newInstance()
+                .path(defaultUrl + "/{resource-id}")
+                .buildAndExpand(resourceId)
+                .toUri();
+    }
+}

--- a/src/test/java/com/petitapetit/miml/domain/playlist/PlayListControllerTest.java
+++ b/src/test/java/com/petitapetit/miml/domain/playlist/PlayListControllerTest.java
@@ -3,13 +3,11 @@ package com.petitapetit.miml.domain.playlist;
 import com.google.gson.Gson;
 import com.petitapetit.miml.domain.playlist.controller.PlayListController;
 import com.petitapetit.miml.domain.playlist.dto.PlayListDto;
-import com.petitapetit.miml.domain.playlist.service.PlayListService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,9 +22,6 @@ public class PlayListControllerTest {
     @InjectMocks
     private PlayListController playListController;
 
-    @Mock
-    private PlayListService playListService;
-
     private MockMvc mockMvc;
 
     @BeforeEach
@@ -39,7 +34,7 @@ public class PlayListControllerTest {
     public void postPlayList() throws Exception {
         //given
 
-        PlayListDto.Post request = new PlayListDto.Post("플레이리스트 이름", true);
+        PlayListDto.SaveRequest request = new PlayListDto.SaveRequest("플레이리스트 이름", true);
 
 
         //when/then

--- a/src/test/java/com/petitapetit/miml/domain/playlist/PlayListControllerTest.java
+++ b/src/test/java/com/petitapetit/miml/domain/playlist/PlayListControllerTest.java
@@ -1,4 +1,4 @@
-package com.petitapetit.miml.domain;
+package com.petitapetit.miml.domain.playlist;
 
 import com.google.gson.Gson;
 import com.petitapetit.miml.domain.playlist.controller.PlayListController;
@@ -35,8 +35,8 @@ public class PlayListControllerTest {
     }
 
     @Test
-    @DisplayName("POST 플레이리스트 등록 컨트롤러 로직 확인")
-    public void savePlayList() throws Exception {
+    @DisplayName("컨트롤러 플레이리스트 등록 로직 확인")
+    public void postPlayList() throws Exception {
         //given
 
         PlayListDto.Post request = new PlayListDto.Post("플레이리스트 이름", true);

--- a/src/test/java/com/petitapetit/miml/domain/playlist/PlayListServiceTest.java
+++ b/src/test/java/com/petitapetit/miml/domain/playlist/PlayListServiceTest.java
@@ -1,0 +1,46 @@
+package com.petitapetit.miml.domain.playlist;
+
+import com.petitapetit.miml.domain.playlist.entity.PlayList;
+import com.petitapetit.miml.domain.playlist.repository.PlayListRepository;
+import com.petitapetit.miml.domain.playlist.service.PlayListService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+public class PlayListServiceTest {
+
+    @InjectMocks
+    private PlayListService playListService;
+
+    @Mock
+    private PlayListRepository playListRepository;
+
+    @DisplayName("서비스 플레이리스트 등록 로직 확인")
+    @Test
+    public void savePlayList(){
+        //given
+        PlayList request = PlayList.builder()
+                .playListId(1L)
+                .name("플레이리스트 이름")
+                .memberId(1L)
+                .publicYN(true).build();
+
+        doReturn(new PlayList(1L, "플레이리스트 이름", 1L, true)).when(playListRepository).save(request);
+
+        //when
+        PlayList savedPlayList = playListService.savePlayList(request);
+
+        //then
+        assertThat(savedPlayList.getPlayListId()).isEqualTo(request.getPlayListId());
+        assertThat(savedPlayList.getName()).isEqualTo("플레이리스트 이름");
+        assertThat(savedPlayList.getMemberId()).isEqualTo(1L);
+        assertThat(savedPlayList.isPublicYN()).isTrue();
+    }
+}

--- a/src/test/java/com/petitapetit/miml/domain/playlist/PlayListServiceTest.java
+++ b/src/test/java/com/petitapetit/miml/domain/playlist/PlayListServiceTest.java
@@ -1,6 +1,8 @@
 package com.petitapetit.miml.domain.playlist;
 
+import com.petitapetit.miml.domain.playlist.dto.PlayListDto;
 import com.petitapetit.miml.domain.playlist.entity.PlayList;
+import com.petitapetit.miml.domain.playlist.mapper.PlayListMapper;
 import com.petitapetit.miml.domain.playlist.repository.PlayListRepository;
 import com.petitapetit.miml.domain.playlist.service.PlayListService;
 import org.junit.jupiter.api.DisplayName;
@@ -20,27 +22,41 @@ public class PlayListServiceTest {
     private PlayListService playListService;
 
     @Mock
+    private PlayListMapper playListMapper;
+
+    @Mock
     private PlayListRepository playListRepository;
 
     @DisplayName("서비스 플레이리스트 등록 로직 확인")
     @Test
     public void savePlayList(){
         //given
-        PlayList request = PlayList.builder()
+        PlayListDto.SaveRequest saveRequest = PlayListDto.SaveRequest.builder()
+                .name("플레이리스트 이름")
+                .isPublic(true)
+                .build();
+
+        PlayList playList = PlayList.builder()
                 .playListId(1L)
                 .name("플레이리스트 이름")
+                .isPublic(true)
                 .memberId(1L)
-                .publicYN(true).build();
+                .build();
 
-        doReturn(new PlayList(1L, "플레이리스트 이름", 1L, true)).when(playListRepository).save(request);
+        PlayListDto.SaveResponse saveResponse = PlayListDto.SaveResponse.builder()
+                        .playListId(1L).build();
+
+
+        doReturn(playList).when(playListMapper).SaveRequestToPlayList(saveRequest, 1L);
+        doReturn(playList).when(playListRepository).save(playList);
+        doReturn(saveResponse).when(playListMapper).PlayListToSaveResponse(playList);
+
 
         //when
-        PlayList savedPlayList = playListService.savePlayList(request);
+        PlayListDto.SaveResponse savedPlayList = playListService.savePlayList(saveRequest, 1L);
 
         //then
-        assertThat(savedPlayList.getPlayListId()).isEqualTo(request.getPlayListId());
-        assertThat(savedPlayList.getName()).isEqualTo("플레이리스트 이름");
-        assertThat(savedPlayList.getMemberId()).isEqualTo(1L);
-        assertThat(savedPlayList.isPublicYN()).isTrue();
+        assertThat(savedPlayList.getPlayListId()).isEqualTo(1L);
+
     }
 }

--- a/src/test/java/com/petitapetit/miml/domain/playlist/PlayListTest.java
+++ b/src/test/java/com/petitapetit/miml/domain/playlist/PlayListTest.java
@@ -1,0 +1,9 @@
+package com.petitapetit.miml.domain.playlist;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class PlayListTest {
+
+
+}


### PR DESCRIPTION
### ✍️ Description
- 플레이리스트 등록, 수정, 조회(플레이리스트 상세 조회, 목록 조회), 삭제 기능을 구현하였습니다. 

<br>

### 🎯 Key Changes
- DTO <-> Entity 를 매핑하는 MapStruct 라이브러리를 사용하였습니다. 
   - 기존에는 엔티티 그대로 Controller에게 반환하였지만, 이에 대해서 필요하지 않은 정보까지 제공한다는 점에서 위험 요소가 된다고 판단하여 Service 계층에서 Mapper에게 entity를 dto로 변환한 것을 위임하였습니다. 
   - MapStruct가 생성한 코드는 다음 디렉토리에 있습니다. `build/generated/sources/annotationProcessor/java/main/com/petitapetit/miml/domain/playlist/mapper/`
- `UriComponentsBuilder`를 통해서 자원이 생성되었을 때 URI를 생성해주는 유틸을 만들어 역할을 분리하였습니다.
- `GlobalExceptionHandler` 에서 @RestControllerAdvice 어노테이션을 통해 여러 컨트롤러에 대해 발생하는 예외에 ExceptionHandler가 적용되도록 하였습니다. 

### 💬 To Reviewers
- `PlayListService` 의 `checkAuthorization`과 `checkExistence`에서 발생하는 예외에 대해서 어떤 상태 코드를 줘야 할지에 대해 의견을 여쭤보고 싶습니다. (해당 코드에 작성된 상태코드는 임의로 작성해놓았습니다.)
