### PR TITLE
Feature/issue#48 알림 기능 비동기로 변경

### DIFF
--- a/src/main/java/com/petitapetit/miml/MimlApplication.java
+++ b/src/main/java/com/petitapetit/miml/MimlApplication.java
@@ -1,48 +1,14 @@
 package com.petitapetit.miml;
 
-import java.util.concurrent.Executor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.task.TaskDecorator;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-@Slf4j
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableAsync
 public class MimlApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(MimlApplication.class, args);
-    }
-
-    @Bean
-    public Executor taskExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(4);
-        executor.setMaxPoolSize(4);
-        executor.setQueueCapacity(500);
-        executor.setThreadNamePrefix("Notification-");
-        executor.initialize();
-
-        executor.setTaskDecorator(new TaskDecorator() {
-            @Override
-            public Runnable decorate(Runnable runnable) {
-                return () -> {
-                    String threadName = Thread.currentThread().getName();
-                    long start = System.currentTimeMillis();
-                    log.info("Starting async task in thread : {}", threadName);
-                    runnable.run();
-                    long end = System.currentTimeMillis();
-                    log.info("It took "+(end-start)+"ms to process the async task.");
-                };
-            }
-        });
-
-        return executor;
     }
 }

--- a/src/main/java/com/petitapetit/miml/MimlApplication.java
+++ b/src/main/java/com/petitapetit/miml/MimlApplication.java
@@ -1,15 +1,30 @@
 package com.petitapetit.miml;
 
+import java.util.concurrent.Executor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableAsync
 public class MimlApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(MimlApplication.class, args);
     }
 
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("Notification-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/petitapetit/miml/MimlApplication.java
+++ b/src/main/java/com/petitapetit/miml/MimlApplication.java
@@ -1,13 +1,16 @@
 package com.petitapetit.miml;
 
 import java.util.concurrent.Executor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.task.TaskDecorator;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+@Slf4j
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableAsync
@@ -25,6 +28,21 @@ public class MimlApplication {
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("Notification-");
         executor.initialize();
+
+        executor.setTaskDecorator(new TaskDecorator() {
+            @Override
+            public Runnable decorate(Runnable runnable) {
+                return () -> {
+                    String threadName = Thread.currentThread().getName();
+                    long start = System.currentTimeMillis();
+                    log.info("Starting async task in thread : {}", threadName);
+                    runnable.run();
+                    long end = System.currentTimeMillis();
+                    log.info("It took "+(end-start)+"ms to process the async task.");
+                };
+            }
+        });
+
         return executor;
     }
 }

--- a/src/main/java/com/petitapetit/miml/domain/notification/TempSongService.java
+++ b/src/main/java/com/petitapetit/miml/domain/notification/TempSongService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -28,7 +27,7 @@ public class TempSongService {
         tempSongRepository.save(newSong);
 
         // song 추가 이벤트 생성 및 발행
-        SongAddedEvent songAddedEvent = new SongAddedEvent(this, newSong);
+        SongAddedEvent songAddedEvent = new SongAddedEvent(newSong);
         try {
             applicationEventPublisher.publishEvent(songAddedEvent);
         } catch (Exception e) {
@@ -37,7 +36,7 @@ public class TempSongService {
     }
 
     private void checkInputValue(String artistName, String songName) {
-        if(artistName == null || songName == null) {
+        if (artistName == null || songName == null) {
             throw new IllegalArgumentException();
         }
     }

--- a/src/main/java/com/petitapetit/miml/domain/notification/entity/FriendRequestedNotification.java
+++ b/src/main/java/com/petitapetit/miml/domain/notification/entity/FriendRequestedNotification.java
@@ -1,6 +1,6 @@
 package com.petitapetit.miml.domain.notification.entity;
 
-import com.petitapetit.miml.domain.notification.TempUser;
+import com.petitapetit.miml.domain.notification.event.FriendRequestedEvent;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,7 +12,11 @@ import javax.persistence.Entity;
 public class FriendRequestedNotification extends Notification {
     private String requestedUserName;  // 친구 요청 받은 유저 이름
 
-    public FriendRequestedNotification(String currentUserEmail, String requestedUserEmail){
+    public static FriendRequestedNotification of(FriendRequestedEvent event) {
+        return new FriendRequestedNotification(event.getCurrentUserName(), event.getRequestedUserName());
+    }
+
+    private FriendRequestedNotification(String currentUserEmail, String requestedUserEmail){
         super(currentUserEmail);
         this.requestedUserName = requestedUserEmail;
     }

--- a/src/main/java/com/petitapetit/miml/domain/notification/entity/SharePlaylistRequestedNotification.java
+++ b/src/main/java/com/petitapetit/miml/domain/notification/entity/SharePlaylistRequestedNotification.java
@@ -1,6 +1,6 @@
 package com.petitapetit.miml.domain.notification.entity;
 
-import com.petitapetit.miml.domain.notification.TempUser;
+import com.petitapetit.miml.domain.notification.event.SharePlaylistRequestedEvent;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,7 +12,11 @@ import javax.persistence.Entity;
 public class SharePlaylistRequestedNotification extends Notification {
     private String requestedUserEmail;  // 친구 요청 받은 유저 이름
 
-    public SharePlaylistRequestedNotification(String currentUserEmail, String requestedUserEmail){
+    public static SharePlaylistRequestedNotification from(SharePlaylistRequestedEvent event) {
+        return new SharePlaylistRequestedNotification(event.getCurrentUserEmail(), event.getRequestedUserEmail());
+    }
+
+    private SharePlaylistRequestedNotification(String currentUserEmail, String requestedUserEmail){
         super(currentUserEmail);
         this.requestedUserEmail = requestedUserEmail;
     }

--- a/src/main/java/com/petitapetit/miml/domain/notification/entity/SongAddedNotification.java
+++ b/src/main/java/com/petitapetit/miml/domain/notification/entity/SongAddedNotification.java
@@ -14,7 +14,11 @@ public class SongAddedNotification extends Notification {
     private String songName;
     private String songArtist;
 
-    public SongAddedNotification(TempUser user, TempSong song){
+    public static SongAddedNotification from(TempSong song, TempUser user){
+        return new SongAddedNotification(user, song);
+    }
+
+    private SongAddedNotification(TempUser user, TempSong song){
         super(user.getEmail());
         this.songArtist = song.getArtist().getName();
         this.songName = song.getName();

--- a/src/main/java/com/petitapetit/miml/domain/notification/event/FriendRequestedEvent.java
+++ b/src/main/java/com/petitapetit/miml/domain/notification/event/FriendRequestedEvent.java
@@ -2,16 +2,14 @@ package com.petitapetit.miml.domain.notification.event;
 
 import com.petitapetit.miml.domain.notification.TempUser;
 import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
 
 @Getter
 // 친구 요청을 했을 때 발행(publish) 될 event
-public class FriendRequestedEvent extends ApplicationEvent {
-    private String currentUserName;  // 친구요청한 유저 이름
-    private String requestedUserName;  // 친구 요청 받은 유저 이름
+public class FriendRequestedEvent {
+    private final String currentUserName;  // 친구요청한 유저 이름
+    private final String requestedUserName;  // 친구 요청 받은 유저 이름
 
-    public FriendRequestedEvent(Object source, TempUser currentUser, TempUser requestedUser) {
-        super(source);
+    public FriendRequestedEvent(TempUser currentUser, TempUser requestedUser) {
         this.currentUserName = currentUser.getEmail();
         this.requestedUserName = requestedUser.getEmail();
     }

--- a/src/main/java/com/petitapetit/miml/domain/notification/event/SharePlaylistRequestedEvent.java
+++ b/src/main/java/com/petitapetit/miml/domain/notification/event/SharePlaylistRequestedEvent.java
@@ -2,16 +2,14 @@ package com.petitapetit.miml.domain.notification.event;
 
 import com.petitapetit.miml.domain.notification.TempUser;
 import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
 
 @Getter
 // 플레이리스트 공유 요청 했을 때 발행(publish) 될 event
-public class SharePlaylistRequestedEvent extends ApplicationEvent {
-    private String currentUserEmail;  // 플레이리스트 공유 요청한 유저 이름
-    private String requestedUserEmail;  // 플레이리스트 공유 요청 받은 유저 이름
+public class SharePlaylistRequestedEvent {
+    private final String currentUserEmail;  // 플레이리스트 공유 요청한 유저 이름
+    private final String requestedUserEmail;  // 플레이리스트 공유 요청 받은 유저 이름
 
-    public SharePlaylistRequestedEvent(Object source, TempUser currentUser, TempUser requestedUser) {
-        super(source);
+    public SharePlaylistRequestedEvent(TempUser currentUser, TempUser requestedUser) {
         this.currentUserEmail = currentUser.getEmail();
         this.requestedUserEmail = requestedUser.getEmail();
     }

--- a/src/main/java/com/petitapetit/miml/domain/notification/event/SongAddedEvent.java
+++ b/src/main/java/com/petitapetit/miml/domain/notification/event/SongAddedEvent.java
@@ -1,15 +1,13 @@
 package com.petitapetit.miml.domain.notification.event;
 
 import com.petitapetit.miml.domain.notification.TempSong;
-import org.springframework.context.ApplicationEvent;
 
 // 신곡이 추가될 때 발행(publish) 될 event
-public class SongAddedEvent extends ApplicationEvent {
+public class SongAddedEvent {
     // 임시 곡
-    private TempSong song;
+    private final TempSong song;
 
-    public SongAddedEvent(Object source, TempSong song) {
-        super(source);
+    public SongAddedEvent(TempSong song) {
         this.song = song;
     }
 

--- a/src/main/java/com/petitapetit/miml/domain/notification/service/NotificationEventHandler.java
+++ b/src/main/java/com/petitapetit/miml/domain/notification/service/NotificationEventHandler.java
@@ -23,7 +23,6 @@ import java.util.*;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-//@Async("asyncExecutor") // 비동기로 처리!
 public class NotificationEventHandler {
 
     private final TempUserRepository userRepository;
@@ -34,8 +33,6 @@ public class NotificationEventHandler {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Async
     public void handleSongEvent(SongAddedEvent event) {
-        log.info("이벤트 감지 : {}",event);
-        log.info("현재 스레드 정보 : {}", Thread.currentThread());
         TempSong song = event.getSong();
 
         Set<TempUser> users = userRepository.findByLikeArtistsSetContaining(song.getArtist());
@@ -54,20 +51,16 @@ public class NotificationEventHandler {
 
     @TransactionalEventListener(classes = FriendRequestedEvent.class, phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Async
     public void handleFriendRequestEvent(FriendRequestedEvent event) {
-        log.debug("이벤트 감지 : {}",event);
-        log.debug("현재 스레드 정보 : {}", Thread.currentThread());
-
         FriendRequestedNotification notification = new FriendRequestedNotification(event.getCurrentUserName(), event.getRequestedUserName());
         mailService.sendEmail(notification);
         notificationRepository.save(notification);
     }
     @TransactionalEventListener(classes = SharePlaylistRequestedEvent.class, phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Async
     public void handleSharePlaylistRequestEvent(SharePlaylistRequestedEvent event) {
-        log.debug("이벤트 감지 : {}",event);
-        log.debug("현재 스레드 정보 : {}", Thread.currentThread());
-
         SharePlaylistRequestedNotification notification = new SharePlaylistRequestedNotification(event.getCurrentUserEmail(), event.getRequestedUserEmail());
         mailService.sendEmail(notification);
         notificationRepository.save(notification);

--- a/src/main/java/com/petitapetit/miml/domain/notification/service/NotificationEventHandler.java
+++ b/src/main/java/com/petitapetit/miml/domain/notification/service/NotificationEventHandler.java
@@ -11,6 +11,7 @@ import com.petitapetit.miml.domain.notification.event.*;
 import com.petitapetit.miml.domain.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +32,7 @@ public class NotificationEventHandler {
 
     @TransactionalEventListener(classes = SongAddedEvent.class, phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Async
     public void handleSongEvent(SongAddedEvent event) {
         log.info("이벤트 감지 : {}",event);
         log.info("현재 스레드 정보 : {}", Thread.currentThread());

--- a/src/main/java/com/petitapetit/miml/domain/notification/service/NotificationEventHandler.java
+++ b/src/main/java/com/petitapetit/miml/domain/notification/service/NotificationEventHandler.java
@@ -44,7 +44,7 @@ public class NotificationEventHandler {
 
     @Transactional(propagation = Propagation.NESTED)
     public void sendToUserAboutNewSongNotification(TempSong song, TempUser user) {
-        SongAddedNotification notification = new SongAddedNotification(user, song);
+        SongAddedNotification notification = SongAddedNotification.from(song, user);
         mailService.sendEmail(notification);
         notificationRepository.save(notification);
     }
@@ -53,15 +53,16 @@ public class NotificationEventHandler {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Async
     public void handleFriendRequestEvent(FriendRequestedEvent event) {
-        FriendRequestedNotification notification = new FriendRequestedNotification(event.getCurrentUserName(), event.getRequestedUserName());
+        FriendRequestedNotification notification = FriendRequestedNotification.of(event);
         mailService.sendEmail(notification);
         notificationRepository.save(notification);
     }
+
     @TransactionalEventListener(classes = SharePlaylistRequestedEvent.class, phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Async
     public void handleSharePlaylistRequestEvent(SharePlaylistRequestedEvent event) {
-        SharePlaylistRequestedNotification notification = new SharePlaylistRequestedNotification(event.getCurrentUserEmail(), event.getRequestedUserEmail());
+        SharePlaylistRequestedNotification notification = SharePlaylistRequestedNotification.from(event);
         mailService.sendEmail(notification);
         notificationRepository.save(notification);
     }

--- a/src/main/java/com/petitapetit/miml/global/config/AsyncConfig.java
+++ b/src/main/java/com/petitapetit/miml/global/config/AsyncConfig.java
@@ -1,0 +1,40 @@
+package com.petitapetit.miml.global.config;
+
+import java.util.concurrent.Executor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Slf4j
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean
+    public Executor asyncTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("Notification-");
+        executor.initialize();
+
+        executor.setTaskDecorator(new TaskDecorator() {
+            @Override
+            public Runnable decorate(Runnable runnable) {
+                return () -> {
+                    String threadName = Thread.currentThread().getName();
+                    long start = System.currentTimeMillis();
+                    log.info("Starting async task in thread : {}", threadName);
+                    runnable.run();
+                    long end = System.currentTimeMillis();
+                    log.info("It took "+(end-start)+"ms to process the async task.");
+                };
+            }
+        });
+
+        return executor;
+    }
+}

--- a/src/test/java/com/petitapetit/miml/domain/notification/AsyncTestConfig.java
+++ b/src/test/java/com/petitapetit/miml/domain/notification/AsyncTestConfig.java
@@ -1,0 +1,25 @@
+package com.petitapetit.miml.domain.notification;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.task.SyncTaskExecutor;
+
+@TestConfiguration
+public class AsyncTestConfig {
+
+    @Bean
+    public AsyncExecutorPostProcessor asyncExecutorPostProcessor() {
+        return new AsyncExecutorPostProcessor();
+    }
+    static class AsyncExecutorPostProcessor implements BeanPostProcessor {
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+            if (beanName.equals("taskExecutor")) {
+                return new SyncTaskExecutor();
+            }
+            return bean;
+        }
+    }
+}

--- a/src/test/java/com/petitapetit/miml/domain/notification/NotificationEventHandlerTest.java
+++ b/src/test/java/com/petitapetit/miml/domain/notification/NotificationEventHandlerTest.java
@@ -38,8 +38,8 @@ public class NotificationEventHandlerTest extends ServiceTest {
     public void testHandleSongEvent() {
         // given
         TempArtist artist = new TempArtist("artist");
-        TempSong song = new TempSong("newSong",artist);
-        SongAddedEvent event = new SongAddedEvent(this,song);
+        TempSong song = new TempSong("newSong", artist);
+        SongAddedEvent event = new SongAddedEvent(song);
         Set<TempUser> users = new HashSet<>();
         users.add(new TempUser());
 
@@ -61,7 +61,7 @@ public class NotificationEventHandlerTest extends ServiceTest {
         Set<TempUser> noUsers = Collections.emptySet();
 
         TempSong songByNoLikedArtists = new TempSong("song", artist);
-        SongAddedEvent event = new SongAddedEvent(this, songByNoLikedArtists);
+        SongAddedEvent event = new SongAddedEvent(songByNoLikedArtists);
 
         when(userRepository.findByLikeArtistsSetContaining(artist)).thenReturn(noUsers);
 
@@ -79,7 +79,7 @@ public class NotificationEventHandlerTest extends ServiceTest {
         // given
         TempUser user1 = new TempUser();
         TempUser user2 = new TempUser();
-        FriendRequestedEvent event = new FriendRequestedEvent(this, user1, user2);
+        FriendRequestedEvent event = new FriendRequestedEvent(user1, user2);
 
         // when
         notificationEventHandler.handleFriendRequestEvent(event);
@@ -95,7 +95,7 @@ public class NotificationEventHandlerTest extends ServiceTest {
         // given
         TempUser user1 = new TempUser();
         TempUser user2 = new TempUser();
-        SharePlaylistRequestedEvent event = new SharePlaylistRequestedEvent(this, user1, user2);
+        SharePlaylistRequestedEvent event = new SharePlaylistRequestedEvent(user1, user2);
 
         // when
         notificationEventHandler.handleSharePlaylistRequestEvent(event);

--- a/src/test/java/com/petitapetit/miml/domain/notification/NotificationTransactionIntegrationTest.java
+++ b/src/test/java/com/petitapetit/miml/domain/notification/NotificationTransactionIntegrationTest.java
@@ -3,24 +3,22 @@ package com.petitapetit.miml.domain.notification;
 import com.petitapetit.miml.domain.mail.serivce.MailService;
 import com.petitapetit.miml.domain.notification.entity.Notification;
 import com.petitapetit.miml.domain.notification.repository.NotificationRepository;
-import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.List;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.context.annotation.Import;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
+@Import({AsyncTestConfig.class})
 public class NotificationTransactionIntegrationTest {
 
     @Autowired
@@ -35,10 +33,6 @@ public class NotificationTransactionIntegrationTest {
     private MailService mailService;
     @Autowired
     private NotificationRepository notificationRepository;
-
-    @Qualifier("taskExecutor")
-    @Autowired
-    private Executor executor;
 
     @BeforeEach
     public void setUp() {
@@ -57,7 +51,7 @@ public class NotificationTransactionIntegrationTest {
 
         // when: addNewSong 메소드 호출하지만 내부 예외 발생
         assertThrows(IllegalArgumentException.class,
-            () -> tempSongService.addNewSong(artistName, songName));
+                () -> tempSongService.addNewSong(artistName, songName));
 
         // then: 저장된 곡과 알림이 없음을 확인
         List<TempSong> songs = tempSongRepository.findAll();
@@ -88,13 +82,13 @@ public class NotificationTransactionIntegrationTest {
         List<TempSong> songs = tempSongRepository.findByArtistName(artistName);
         List<Notification> notifications = notificationRepository.findAll();
         assertTrue(
-            songs.stream().anyMatch(song -> song.getName().equals(songName)));
+                songs.stream().anyMatch(song -> song.getName().equals(songName)));
         assertTrue(notifications.isEmpty());
     }
 
     @Test
     @DisplayName("음악 생성이 성공 시 알림이 저장되어야 한다.")
-    public void testEventOnSongCreationSuccess() throws InterruptedException {
+    public void testEventOnSongCreationSuccess() {
         // given: 유저 생성, 아티스트 이름과 노래 이름 설정
         String artistName = "Artist1";
         String songName = "Song1";
@@ -107,10 +101,6 @@ public class NotificationTransactionIntegrationTest {
 
         // when: addNewSong 메소드 호출
         tempSongService.addNewSong(artistName, songName);
-
-        // 비동기 작업 종료 대기
-        ThreadPoolTaskExecutor threadPoolTaskExecutor = (ThreadPoolTaskExecutor) executor;
-        threadPoolTaskExecutor.getThreadPoolExecutor().awaitTermination(1, TimeUnit.SECONDS);
 
         // then: 신곡 추가 이벤트가 발생했음을 확인
         List<TempSong> songs = tempSongRepository.findAll();

--- a/src/test/java/com/petitapetit/miml/domain/notification/NotificationTransactionIntegrationTest.java
+++ b/src/test/java/com/petitapetit/miml/domain/notification/NotificationTransactionIntegrationTest.java
@@ -3,7 +3,6 @@ package com.petitapetit.miml.domain.notification;
 import com.petitapetit.miml.domain.mail.serivce.MailService;
 import com.petitapetit.miml.domain.notification.entity.Notification;
 import com.petitapetit.miml.domain.notification.repository.NotificationRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,15 +11,16 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.List;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @SpringBootTest
 @Import({AsyncTestConfig.class})
 public class NotificationTransactionIntegrationTest {
-
     @Autowired
     private TempSongRepository tempSongRepository;
     @Autowired
@@ -33,14 +33,6 @@ public class NotificationTransactionIntegrationTest {
     private MailService mailService;
     @Autowired
     private NotificationRepository notificationRepository;
-
-    @BeforeEach
-    public void setUp() {
-        notificationRepository.deleteAll();
-        tempSongRepository.deleteAll();
-        tempArtistRepository.deleteAll();
-        tempUserRepository.deleteAll();
-    }
 
     @Test
     @DisplayName("음악 생성이 실패 시 이벤트가 발행되지 않아야 한다.")


### PR DESCRIPTION
### ✍️ Description
- 리소스를 효율적으로 사용하고 빠른 반응 속도를 위해 이벤트 처리를 비동기로 변경했습니다. 

<br>

### 🎯 Key Changes
- 비동기 작업을 수행하는 메서드에 `@Async` 사용
- 비동기 작업을 수행하기 위한 `Executor` 선언
- 테스트 코드에서 1초 더 기다리도록 변경
  - 해당 방법은 비동기를 동기로 변경하면서 기다리지 않게 되었습니다

<br>

### 💬 To Reviewers
- 각 이벤트를 처리하는 코드가 보기 불편하지 않으신가요?
  - 비동기 작업을 확인하기 위해 로깅 작업을 AOP로 분리하면 어떨까 합니다 
- 테스트 시 기존 스레드가 먼저 끝나면 테스트를 통과할 수 없어 1초를 기다리도록 하고 있는데 좋은 테스트는 아니라고 생각합니다.😢

close #48 