### PR TITLE
Feature/issue#62 - SimpleAuthFilter 추가

### DIFF
--- a/src/main/java/com/petitapetit/miml/domain/auth/oauth/filter/SimpleAuthFilter.java
+++ b/src/main/java/com/petitapetit/miml/domain/auth/oauth/filter/SimpleAuthFilter.java
@@ -1,0 +1,62 @@
+package com.petitapetit.miml.domain.auth.oauth.filter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.petitapetit.miml.domain.auth.oauth.CustomOAuth2User;
+import com.petitapetit.miml.domain.auth.oauth.OAuth2Provider;
+import com.petitapetit.miml.domain.auth.oauth.userinfo.SpotifyUserInfo;
+import com.petitapetit.miml.domain.member.model.Member;
+import com.petitapetit.miml.domain.member.model.RoleType;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class SimpleAuthFilter extends OncePerRequestFilter {
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		if (request.getHeader(HttpHeaders.AUTHORIZATION) != null) {
+			String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+			Map<String, Object> attribute = Map.of(
+				"id", "spotify",
+				"accessToken", accessToken
+			);
+
+			SecurityContextHolder.getContext().setAuthentication(
+				new OAuth2AuthenticationToken(
+					new CustomOAuth2User(new SpotifyUserInfo(attribute), createMember(), accessToken),
+					Collections.emptySet(),
+					"id"
+				)
+			);
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	private Member createMember() {
+		return Member.builder()
+			.memberId(1000L)
+			.name("name")
+			.email("email")
+			.image("image")
+			.role(RoleType.ROLE_USER)
+			.provider(OAuth2Provider.SPOTIFY)
+			.providerId("provider_id")
+			.build();
+	}
+}

--- a/src/main/java/com/petitapetit/miml/domain/auth/oauth/filter/SimpleAuthFilter.java
+++ b/src/main/java/com/petitapetit/miml/domain/auth/oauth/filter/SimpleAuthFilter.java
@@ -29,17 +29,11 @@ public class SimpleAuthFilter extends OncePerRequestFilter {
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
-
 		if (request.getHeader(HttpHeaders.AUTHORIZATION) != null) {
 			String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
-			Map<String, Object> attribute = Map.of(
-				"id", "spotify",
-				"accessToken", accessToken
-			);
-
 			SecurityContextHolder.getContext().setAuthentication(
 				new OAuth2AuthenticationToken(
-					new CustomOAuth2User(new SpotifyUserInfo(attribute), createMember(), accessToken),
+					new CustomOAuth2User(createSpotifyUserInfo(accessToken), createMember(), accessToken),
 					Collections.emptySet(),
 					"id"
 				)
@@ -58,5 +52,13 @@ public class SimpleAuthFilter extends OncePerRequestFilter {
 			.provider(OAuth2Provider.SPOTIFY)
 			.providerId("provider_id")
 			.build();
+	}
+
+	private SpotifyUserInfo createSpotifyUserInfo(String accessToken) {
+		Map<String, Object> attribute = Map.of(
+			"id", "spotify",
+			"accessToken", accessToken
+		);
+		return new SpotifyUserInfo(attribute);
 	}
 }

--- a/src/main/java/com/petitapetit/miml/global/config/SecurityConfig.java
+++ b/src/main/java/com/petitapetit/miml/global/config/SecurityConfig.java
@@ -6,11 +6,13 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 import com.petitapetit.miml.domain.auth.oauth.CustomOAuth2UserService;
 import com.petitapetit.miml.domain.auth.oauth.filter.OriginalUriFilter;
+import com.petitapetit.miml.domain.auth.oauth.filter.SimpleAuthFilter;
 import com.petitapetit.miml.domain.auth.oauth.handler.OAuth2AuthenticationSuccessHandler;
 import com.petitapetit.miml.domain.auth.oauth.handler.OAuth2AuthenticationFailureHandler;
 
@@ -49,7 +51,8 @@ public class SecurityConfig {
 				.successHandler(oAuth2AuthenticationSuccessHandler)
 				.failureHandler(oAuth2AuthenticationFailureHandler)
 			)
-			.addFilterBefore(new OriginalUriFilter(), BasicAuthenticationFilter.class);
+			.addFilterBefore(new OriginalUriFilter(), BasicAuthenticationFilter.class)
+			.addFilterBefore(new SimpleAuthFilter(), OAuth2LoginAuthenticationFilter.class);
 
 		return http.build();
 	}


### PR DESCRIPTION
### ✍️ Description
- 브라우저 요청 시 문제 없지만, 포스트맨 요청 시 로그인 페이지로 리다이렉트되는 문제가 발생했습니다.
- 이유는, `HttpServletResponse` 객체를 사용하여 새로운 URL로 리다이렉트할 때, 현재 요청과 관련된 `HttpServletRequest`에 대한 정보가 자동으로 비워지기 때문입니다.

<br>

### 🎯 Key Changes
- 이를 해결하기 위해 SimpleAuthFilter에서 Spring Security의 SecurityContextHolder에 사용자 인증 정보를 설정합니다.
    - SimpleAuthFilter는 필터 체인 중 OAuth2LoginAuthenticationFilter 이전에 위치시켜 OAuth2LoginAuthenticationFilter에서 인증된 사용자의 정보를 가져올 수 있도록 합니다.
- 액세스 토큰을 제외한 사용자 정보는 dummy data로 저장합니다.

<br>

### 💬 To Reviewers
- @Nine-JH 혹시 설명이 미흡한 부분이 있다면 코멘트 부탁드리겠습니다..!!
